### PR TITLE
add #include <vector> in gemm_test.cc

### DIFF
--- a/gemm_test.cc
+++ b/gemm_test.cc
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <functional>
 #include <iostream>
+#include <vector>
 
 #include <cuda_runtime.h>
 


### PR DESCRIPTION
Fix compile erro

```shell
nvcc -c -O3 gemm_test.cc -o gemm_test.o
gemm_test.cc:35:6: error: ‘vector’ in namespace ‘std’ does not name a template type
   35 | std::vector<GemmImpl> gemm_impls = {
      |      ^~~~~~
gemm_test.cc:17:1: note: ‘std::vector’ is defined in header ‘<vector>’; did you forget to ‘#include <vector>’?
   16 | #include "gemm_gpu_tiling.h"
  +++ |+#include <vector>
   17 | 
```