### PR TITLE
Exchange loop order to optimize executation time of CPU version

### DIFF
--- a/gemm_cpu_naive.cc
+++ b/gemm_cpu_naive.cc
@@ -20,8 +20,8 @@ void gemm_cpu_naive(
 	const int m,
 	const int k
 ) {
-	for (int l = 0; l < k; ++l)
-		for (int i = 0; i < n; ++i)
+	for (int i = 0; i < n; ++i)
+		for (int l = 0; l < k; ++l)
 			for (int j = 0; j < m; ++j) {
 				C[i * m + j] += A[i * k + l] * B[l * m + j];
 			}

--- a/gemm_cpu_simd.cc
+++ b/gemm_cpu_simd.cc
@@ -20,8 +20,8 @@ void gemm_cpu_simd(
 	const int m,
 	const int k
 ) {
-	for (int l = 0; l < k; ++l)
-		for (int i = 0; i < n; ++i)
+	for (int i = 0; i < n; ++i)
+		for (int l = 0; l < k; ++l)
 			for (int j = 0; j < m; ++j) {
 				C[i * m + j] += A[i * k + l] * B[l * m + j];
 			}


### PR DESCRIPTION
The change is about locality.

In my machine,
```
before:
       cpu_native          195.00 us
       cpu_simd            76.39 us
after:
       cpu_naive           193.00 us
       cpu_simd            64.62 us
```

Certainly this is not important at all because the course focuses on GPU programming. 